### PR TITLE
Remove dark overlay and center skyscraper image in hero

### DIFF
--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -2,7 +2,7 @@ import HeroHeader from "./HeroHeader";
 const HeroSection = () => {
   return <section className="relative min-h-screen overflow-hidden bg-[#1e9ce8]">
       {/* Background Image */}
-      <div className="absolute inset-0 z-0">
+      <div className="absolute inset-0 z-5">
         <div className="relative w-full h-full">
           <img
             src="https://api.builder.io/api/v1/image/assets/TEMP/fe4fc4a1a6bfccd699aa5c93bed1e16b23886754?width=1632"


### PR DESCRIPTION
## Purpose
The user wanted to improve the hero section's visual presentation by removing the dark background overlay that was obscuring the content and repositioning the skyscraper image to be more prominently displayed below the main heading text.

## Code changes
- **Removed dark gradient background**: Eliminated the linear gradient overlay (`#1a1a1a` to `#0a0a0a`) that was creating a dark film effect
- **Simplified background structure**: Removed the complex blurred background image setup and overlay layers
- **Repositioned skyscraper image**: Added a new centered skyscraper image positioned at the bottom of the hero section using responsive sizing (`h-3/5` on mobile, `h-3/4` on tablet, `h-4/5` on desktop)
- **Updated text styling**: Changed hero content text color to match the brand blue (`rgba(30, 156, 232, 1)`)
- **Improved z-index layering**: Reorganized the layering structure to ensure proper visibility of all elements

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 7`

🔗 [Edit in Builder.io](https://builder.io/app/projects/1f663ab0e06d4bf4886f05d173f31590/zen-field)

👀 [Preview Link](https://1f663ab0e06d4bf4886f05d173f31590-zen-field.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>1f663ab0e06d4bf4886f05d173f31590</projectId>-->
<!--<branchName>zen-field</branchName>-->