### PR TITLE
Remove grayscale filter from marquee logos

### DIFF
--- a/src/components/ui/marquee.tsx
+++ b/src/components/ui/marquee.tsx
@@ -113,7 +113,7 @@ export function MarqueeDemo() {
               src={logo.src}
               alt={`${logo.name} logo`}
               className={cn(
-                "object-contain filter grayscale group-hover:grayscale-0 transition-all duration-500 opacity-70 group-hover:opacity-100 group-hover:scale-110",
+                "object-contain transition-all duration-500 opacity-90 group-hover:opacity-100 group-hover:scale-110",
                 logo.className
               )}
               loading="lazy"
@@ -129,7 +129,7 @@ export function MarqueeDemo() {
               src={logo.src}
               alt={`${logo.name} logo`}
               className={cn(
-                "object-contain filter grayscale group-hover:grayscale-0 transition-all duration-500 opacity-70 group-hover:opacity-100 group-hover:scale-110",
+                "object-contain transition-all duration-500 opacity-90 group-hover:opacity-100 group-hover:scale-110",
                 logo.className
               )}
               loading="lazy"


### PR DESCRIPTION
## Purpose
Remove the black and white grayscale filter from marquee logos to display them in their original brand colors, improving visual appeal and brand recognition.

## Code changes
- Removed `filter grayscale` and `group-hover:grayscale-0` classes from logo images in the marquee component
- Increased default opacity from 70% to 90% to maintain visual hierarchy while showing colors
- Preserved hover effects (scale and full opacity) for interactive feedback

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 23`

🔗 [Edit in Builder.io](https://builder.io/app/projects/5c0d93e074934a939152117acd5fca49/curry-space)

👀 [Preview Link](https://5c0d93e074934a939152117acd5fca49-curry-space.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>5c0d93e074934a939152117acd5fca49</projectId>-->
<!--<branchName>curry-space</branchName>-->