### PR TITLE
Add clickable map image to footer with Google Maps link

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -110,11 +110,18 @@ const Footer = () => {
 
       {/* Map Image Section */}
       <div className="w-full mt-0">
-        <img
-          src="https://cdn.builder.io/api/v1/image/assets%2F371acd9a25a7494cb5e15d62a5f4d89c%2Fd52d9448f2d5461f9a0215f26865e76a"
-          alt="Location map"
-          className="w-full h-auto object-cover"
-        />
+        <a
+          href="https://www.google.com/maps/place/MPHD+Group+(SearchRent.in)/@21.1533533,79.132809,17z/data=!4m14!1m7!3m6!1s0x3bd4c74de6f51b47:0x125118ce7e76fd3a!2sMPHD+Group+(SearchRent.in)!8m2!3d21.1533533!4d79.132809!16s%2Fg%2F11rfq37mv7!3m5!1s0x3bd4c74de6f51b47:0x125118ce7e76fd3a!8m2!3d21.1533533!4d79.132809!16s%2Fg%2F11rfq37mv7?entry=ttu&g_ep=EgoyMDI1MDgwMy4wIKXMDSoASAFQAw%3D%3D"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="block"
+        >
+          <img
+            src="https://cdn.builder.io/api/v1/image/assets%2F371acd9a25a7494cb5e15d62a5f4d89c%2F7c93f3751ffe4a61ab3d8596cafee3ca"
+            alt="Location map"
+            className="w-full h-auto object-cover"
+          />
+        </a>
       </div>
     </footer>
   );


### PR DESCRIPTION
## Purpose
The user requested to add a map image to the footer section and link it to a specific Google Maps location for MPHD Group (SearchRent.in). This enhancement provides users with a visual reference and direct access to the company's location on Google Maps.

## Code changes
- Added a new map image section below the existing footer content in `Footer.tsx`
- Implemented a clickable image that opens Google Maps in a new tab
- Used proper accessibility attributes (`alt` text, `rel="noopener noreferrer"`)
- Applied responsive styling with `w-full` and `h-auto` classes
- Linked to the specific Google Maps location for MPHD Group with coordinates and place details

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 32`

🔗 [Edit in Builder.io](https://builder.io/app/projects/68bee804e1bb406d81de189d7dbd620b/flare-forge)

👀 [Preview Link](https://68bee804e1bb406d81de189d7dbd620b-flare-forge.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>68bee804e1bb406d81de189d7dbd620b</projectId>-->
<!--<branchName>flare-forge</branchName>-->