### PR TITLE
Add custom spacing styles to CommitmentSection layout

### DIFF
--- a/src/components/CommitmentSection.tsx
+++ b/src/components/CommitmentSection.tsx
@@ -91,17 +91,19 @@ const CommitmentSection = () => {
     <>
       <section className="bg-white" style={{ paddingTop: '59px' }}>
         <div className="container mx-auto px-4 lg:px-8 max-w-7xl">
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 lg:gap-16 xl:gap-24 items-center">
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 lg:gap-16 xl:gap-24 items-center" style={{ marginBottom: '44px' }}>
             {/* Left Content */}
             <motion.div
               className="space-y-8"
               {...staggerChildren}
               viewport={{ once: true, margin: "-100px" }}
+              style={{ marginBottom: '-2px' }}
             >
               {/* Main Heading */}
               <motion.h2
                 className="font-instrument text-3xl md:text-4xl lg:text-5xl xl:text-6xl font-normal text-black leading-tight tracking-tight"
                 variants={textReveal}
+                style={{ paddingBottom: '23px' }}
               >
                 With a commitment to excellence and customer satisfaction.
               </motion.h2>
@@ -110,6 +112,7 @@ const CommitmentSection = () => {
               <motion.p
                 className="text-[#5D5D5D] text-lg leading-relaxed"
                 variants={textReveal}
+                style={{ margin: '3px 0 35px' }}
               >
                 With a commitment to innovation, sustainability, and precision, we bring your ideas to life while enhancing functionality and aesthetics. Our team of dedicated architects and designers is here to turn your unique vision into a tangible masterpiece.
               </motion.p>
@@ -119,6 +122,7 @@ const CommitmentSection = () => {
                 href="https://bae3d00ef19341029c10c22b2986b118-460282766e5d4212bb58f5dc1.fly.dev/properties"
                 className="bg-[#131313] text-white px-8 py-4 rounded-full text-lg font-medium hover:bg-gray-800 transition-colors cursor-pointer"
                 variants={textReveal}
+                style={{ padding: '13px 32px 16px' }}
               >
                 Learn more
               </motion.a>


### PR DESCRIPTION
## Purpose
Based on the conversation history, the user was working on visual changes to the CommitmentSection component, specifically focusing on layout adjustments and spacing improvements to enhance the visual presentation of the commitment section.

## Code changes
- Added `marginBottom: '44px'` to the main grid container for better section spacing
- Applied `marginBottom: '-2px'` to the left content motion div for fine-tuned positioning
- Added `paddingBottom: '23px'` to the main heading for improved text spacing
- Set custom margin `'3px 0 35px'` on the description paragraph for better vertical rhythm
- Updated button padding to `'13px 32px 16px'` for more balanced button appearance

These changes implement precise spacing adjustments throughout the CommitmentSection component to improve the overall visual layout and typography spacing.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 39`

🔗 [Edit in Builder.io](https://builder.io/app/projects/6276f2b6c3d04b25bb4acdd83e5f02ba/flare-den)

👀 [Preview Link](https://6276f2b6c3d04b25bb4acdd83e5f02ba-flare-den.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>6276f2b6c3d04b25bb4acdd83e5f02ba</projectId>-->
<!--<branchName>flare-den</branchName>-->