### PR TITLE
Add framer-motion animations to Services page

### DIFF
--- a/src/pages/Services.tsx
+++ b/src/pages/Services.tsx
@@ -354,14 +354,19 @@ const Services = () => {
                   <h3 className="font-instrument text-xl md:text-2xl lg:text-3xl font-normal text-gray-800 tracking-tight pr-8">
                     {item.question}
                   </h3>
-                  <div className="flex-shrink-0 w-12 h-12 bg-gray-900 rounded-full flex items-center justify-center">
-                    <svg 
-                      width="19" 
-                      height="19" 
-                      viewBox="0 0 19 19" 
-                      fill="none" 
+                  <motion.div
+                    className="flex-shrink-0 w-12 h-12 bg-gray-900 rounded-full flex items-center justify-center"
+                    whileHover={{ scale: 1.1 }}
+                    transition={{ type: "spring", stiffness: 400, damping: 17 }}
+                  >
+                    <motion.svg
+                      width="19"
+                      height="19"
+                      viewBox="0 0 19 19"
+                      fill="none"
                       xmlns="http://www.w3.org/2000/svg"
-                      className={`transition-transform duration-200 ${openFAQ === index ? 'rotate-45' : ''}`}
+                      animate={{ rotate: openFAQ === index ? 45 : 0 }}
+                      transition={{ duration: 0.3, ease: "easeInOut" }}
                     >
                       <path 
                         d="M6.12439 5.42871H13.3475V12.6518M12.8459 5.93032L5.52246 13.2538" 
@@ -370,8 +375,8 @@ const Services = () => {
                         strokeMiterlimit="10" 
                         strokeLinecap="square"
                       />
-                    </svg>
-                  </div>
+                    </motion.svg>
+                  </motion.div>
                 </motion.button>
                 {openFAQ === index && (
                   <motion.div


### PR DESCRIPTION
## Purpose
The user requested to copy all animations from the landing page and add them to the Services page to create a consistent animated experience across the application.

## Code changes
- **Added framer-motion import** and comprehensive animation variants for different UI elements
- **Wrapped components with motion.div** including the main container, navbar, background image, form sections, FAQ items, and footer
- **Implemented staggered animations** with containerVariants and itemVariants for sequential element reveals
- **Added specialized animations** including:
  - Fade-in and scale effects for headlines and text
  - Slide-up animations for form fields and FAQ items
  - Hover interactions for buttons and FAQ toggles
  - Smooth expand/collapse for FAQ answers
- **Applied viewport-triggered animations** using `whileInView` for sections that animate when scrolled into view
- **Enhanced user interactions** with hover and tap animations on interactive elements

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 43`

🔗 [Edit in Builder.io](https://builder.io/app/projects/5d114323e54a46308ca23e1c955baed8/mystic-nest)

👀 [Preview Link](https://5d114323e54a46308ca23e1c955baed8-mystic-nest.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>5d114323e54a46308ca23e1c955baed8</projectId>-->
<!--<branchName>mystic-nest</branchName>-->