### PR TITLE
Split Industrial Properties heading into two lines

### DIFF
--- a/src/pages/Industrial.tsx
+++ b/src/pages/Industrial.tsx
@@ -101,8 +101,9 @@ const Industrial = () => {
         />
         <div className="absolute inset-0 bg-gradient-to-r from-black/30 to-transparent" />
         <div className="absolute inset-0 flex items-center justify-start pl-10">
-          <h1 className="text-white font-instrument text-8xl md:text-[180px] font-normal leading-tight tracking-tight">
-            <p>Industrial Properties</p>
+          <h1 className="text-left text-white font-instrument text-8xl md:text-[180px] font-normal leading-tight tracking-tight">
+            <p>Industrial </p>
+            <p>Properties</p>
           </h1>
         </div>
       </div>


### PR DESCRIPTION
## Purpose
Based on the conversation history, the user wanted to make visual changes to the Industrial page layout, specifically modifying how the main heading is displayed.

## Code changes
- Split the "Industrial Properties" heading into two separate lines by wrapping each word in its own `<p>` tag
- Added `text-left` class to the heading for explicit left alignment
- The heading now displays "Industrial" on the first line and "Properties" on the second line, maintaining the same styling but with improved visual layout

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 60`

🔗 [Edit in Builder.io](https://builder.io/app/projects/32892101d7f440ca89ab22894a83068d/aura-home)

👀 [Preview Link](https://32892101d7f440ca89ab22894a83068d-aura-home.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>32892101d7f440ca89ab22894a83068d</projectId>-->
<!--<branchName>aura-home</branchName>-->