### PR TITLE
Hide AI assistant button and apply widget styling

### DIFF
--- a/src/components/ui/ai-assistant-button.tsx
+++ b/src/components/ui/ai-assistant-button.tsx
@@ -182,7 +182,7 @@ export function AIAssistantButton({ className, isMobile = false }: AIAssistantBu
       onClick={handleClick}
       className={cn(
         // Base styles
-        "backdrop-blur-sm border rounded-full text-white transition-all duration-200 bg-white/10 border-white/20 hover:bg-white/20 group relative flex flex-row overflow-auto",
+        "hidden backdrop-blur-sm border rounded-full text-white transition-all duration-200 bg-white/10 border-white/20 hover:bg-white/20 group relative flex flex-row overflow-auto",
         // Mobile vs Desktop responsive styling
         isMobile
           ? "w-12 h-12 justify-center" // Compact circular button for mobile

--- a/src/components/ui/ai-assistant-button.tsx
+++ b/src/components/ui/ai-assistant-button.tsx
@@ -204,7 +204,7 @@ export function AIAssistantButton({ className, isMobile = false }: AIAssistantBu
 
       {/* Text only shown on desktop */}
       {!isMobile && (
-        <span className="hidden sm:inline text-sm">
+        <span className="hidden">
           {voiceAgentLoaded ? "Voice Assistant" : "AI Assistant"}
         </span>
       )}

--- a/src/components/ui/ai-assistant-button.tsx
+++ b/src/components/ui/ai-assistant-button.tsx
@@ -33,6 +33,23 @@ export function AIAssistantButton({ className, isMobile = false }: AIAssistantBu
           convaiWidget = document.createElement('elevenlabs-convai');
           convaiWidget.id = 'elevenlabs-convai-widget';
           convaiWidget.setAttribute('agent-id', 'agent_9601k3c0dph4eezaj7qxsf837x4z');
+
+          // Apply styles to match the diff requirements
+          Object.assign(convaiWidget.style, {
+            bottom: '0px',
+            color: 'rgb(0, 0, 0)',
+            display: 'block',
+            fontFamily: 'Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif',
+            fontWeight: '400',
+            left: '0px',
+            pointerEvents: 'auto',
+            position: 'fixed',
+            right: '0px',
+            scrollbarColor: 'rgb(229, 231, 235) rgba(0, 0, 0, 0)',
+            top: '192px',
+            zIndex: '1000'
+          });
+
           document.body.appendChild(convaiWidget);
 
           console.log('ElevenLabs voice agent widget created');
@@ -46,6 +63,23 @@ export function AIAssistantButton({ className, isMobile = false }: AIAssistantBu
         convaiWidget = document.createElement('elevenlabs-convai');
         convaiWidget.id = 'elevenlabs-convai-widget';
         convaiWidget.setAttribute('agent-id', 'agent_9601k3c0dph4eezaj7qxsf837x4z');
+
+        // Apply styles to match the diff requirements
+        Object.assign(convaiWidget.style, {
+          bottom: '0px',
+          color: 'rgb(0, 0, 0)',
+          display: 'block',
+          fontFamily: 'Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif',
+          fontWeight: '400',
+          left: '0px',
+          pointerEvents: 'auto',
+          position: 'fixed',
+          right: '0px',
+          scrollbarColor: 'rgb(229, 231, 235) rgba(0, 0, 0, 0)',
+          top: '192px',
+          zIndex: '1000'
+        });
+
         document.body.appendChild(convaiWidget);
         console.log('ElevenLabs voice agent widget created (script existed)');
       }
@@ -148,7 +182,7 @@ export function AIAssistantButton({ className, isMobile = false }: AIAssistantBu
       onClick={handleClick}
       className={cn(
         // Base styles
-        "flex items-center backdrop-blur-sm border rounded-full text-white transition-all duration-200 bg-white/10 border-white/20 hover:bg-white/20 group relative",
+        "backdrop-blur-sm border rounded-full text-white transition-all duration-200 bg-white/10 border-white/20 hover:bg-white/20 group relative flex flex-row overflow-auto",
         // Mobile vs Desktop responsive styling
         isMobile
           ? "w-12 h-12 justify-center" // Compact circular button for mobile


### PR DESCRIPTION
## Purpose
The user requested to hide the AI assistant button from the UI by making it invisible and positioning it behind other elements. The goal was to remove the button's visibility while maintaining its functionality.

## Code changes
- **Button visibility**: Changed button classes from `flex items-center` to `hidden` to make the AI assistant button invisible
- **Text label**: Hidden the desktop text span by changing `hidden sm:inline` to `hidden`
- **Widget styling**: Added comprehensive CSS styling to the ElevenLabs ConvAI widget including:
  - Fixed positioning with specific coordinates (top: 192px)
  - Z-index management (z-index: 1000)
  - Font family and styling properties
  - Layout properties (display, pointer-events, etc.)
- **Code duplication**: Applied the same styling changes to both widget creation paths in the component

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 75`

🔗 [Edit in Builder.io](https://builder.io/app/projects/6085b987de594c428e7928993f4e2caf/neon-haven)

👀 [Preview Link](https://6085b987de594c428e7928993f4e2caf-neon-haven.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>6085b987de594c428e7928993f4e2caf</projectId>-->
<!--<branchName>neon-haven</branchName>-->