### PR TITLE
Refactor voice agent to global hook and remove AI button

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,6 +26,7 @@ const App = () => (
     <TooltipProvider>
       <Toaster />
       <Sonner />
+      <VoiceAgent />
       <BrowserRouter>
         <ScrollToTop />
         <Routes>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,7 @@ import ResidentialRental from "./pages/ResidentialRental";
 import Industrial from "./pages/Industrial";
 import NotFound from "./pages/NotFound";
 import ScrollToTop from "./components/ScrollToTop";
+import { VoiceAgent } from "./components/VoiceAgent";
 
 const queryClient = new QueryClient();
 

--- a/src/components/VoiceAgent.tsx
+++ b/src/components/VoiceAgent.tsx
@@ -1,0 +1,7 @@
+import { useVoiceAgent } from "@/hooks/use-voice-agent";
+
+// This component loads the voice agent globally
+export function VoiceAgent() {
+  useVoiceAgent();
+  return null; // This component doesn't render anything
+}

--- a/src/components/ui/ai-assistant-button.tsx
+++ b/src/components/ui/ai-assistant-button.tsx
@@ -1,7 +1,8 @@
-import React, { useEffect, useState } from "react";
+import React from "react";
 import { MessageCircle, Sparkles } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 import { cn } from "@/lib/utils";
+import { useVoiceAgent } from "@/hooks/use-voice-agent";
 
 interface AIAssistantButtonProps {
   className?: string;
@@ -10,165 +11,16 @@ interface AIAssistantButtonProps {
 
 export function AIAssistantButton({ className, isMobile = false }: AIAssistantButtonProps) {
   const navigate = useNavigate();
-  const [voiceAgentLoaded, setVoiceAgentLoaded] = useState(false);
-  const [voiceAgentActive, setVoiceAgentActive] = useState(false);
-
-  useEffect(() => {
-    // Add the ElevenLabs ConvAI script exactly as provided
-    const script = document.createElement('script');
-    script.src = 'https://unpkg.com/@elevenlabs/convai-widget-embed';
-    script.async = true;
-    script.type = 'text/javascript';
-    script.id = 'elevenlabs-convai-script';
-
-    // Only add if not already present
-    if (!document.getElementById('elevenlabs-convai-script')) {
-      document.head.appendChild(script);
-
-      // Wait for script to load before creating widget
-      script.onload = () => {
-        // Add the ConvAI widget element exactly as provided
-        let convaiWidget = document.getElementById('elevenlabs-convai-widget');
-        if (!convaiWidget) {
-          convaiWidget = document.createElement('elevenlabs-convai');
-          convaiWidget.id = 'elevenlabs-convai-widget';
-          convaiWidget.setAttribute('agent-id', 'agent_9601k3c0dph4eezaj7qxsf837x4z');
-
-          // Apply styles to match the diff requirements
-          Object.assign(convaiWidget.style, {
-            bottom: '0px',
-            color: 'rgb(0, 0, 0)',
-            display: 'block',
-            fontFamily: 'Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif',
-            fontWeight: '400',
-            left: '0px',
-            pointerEvents: 'auto',
-            position: 'fixed',
-            right: '0px',
-            scrollbarColor: 'rgb(229, 231, 235) rgba(0, 0, 0, 0)',
-            top: '192px',
-            zIndex: '1000'
-          });
-
-          document.body.appendChild(convaiWidget);
-
-          console.log('ElevenLabs voice agent widget created');
-          setVoiceAgentLoaded(true);
-        }
-      };
-    } else {
-      // Script already exists, check if widget exists
-      let convaiWidget = document.getElementById('elevenlabs-convai-widget');
-      if (!convaiWidget) {
-        convaiWidget = document.createElement('elevenlabs-convai');
-        convaiWidget.id = 'elevenlabs-convai-widget';
-        convaiWidget.setAttribute('agent-id', 'agent_9601k3c0dph4eezaj7qxsf837x4z');
-
-        // Apply styles to match the diff requirements
-        Object.assign(convaiWidget.style, {
-          bottom: '0px',
-          color: 'rgb(0, 0, 0)',
-          display: 'block',
-          fontFamily: 'Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif',
-          fontWeight: '400',
-          left: '0px',
-          pointerEvents: 'auto',
-          position: 'fixed',
-          right: '0px',
-          scrollbarColor: 'rgb(229, 231, 235) rgba(0, 0, 0, 0)',
-          top: '192px',
-          zIndex: '1000'
-        });
-
-        document.body.appendChild(convaiWidget);
-        console.log('ElevenLabs voice agent widget created (script existed)');
-      }
-      setVoiceAgentLoaded(true);
-    }
-
-    // Additional check for widget availability
-    const checkWidget = setTimeout(() => {
-      const widget = document.querySelector('elevenlabs-convai');
-      if (widget) {
-        console.log('ElevenLabs voice agent widget found:', widget);
-        setVoiceAgentLoaded(true);
-      } else {
-        console.log('ElevenLabs voice agent widget not found');
-      }
-    }, 3000);
-
-    return () => {
-      clearTimeout(checkWidget);
-      // Cleanup on component unmount
-      const existingScript = document.getElementById('elevenlabs-convai-script');
-      if (existingScript) {
-        existingScript.remove();
-      }
-      const existingWidget = document.getElementById('elevenlabs-convai-widget');
-      if (existingWidget) {
-        existingWidget.remove();
-      }
-    };
-  }, []);
+  const { voiceAgentLoaded, activateVoiceAgent } = useVoiceAgent();
 
   const handleClick = () => {
     console.log('AI Assistant button clicked, voiceAgentLoaded:', voiceAgentLoaded);
 
     if (voiceAgentLoaded) {
-      // Try to activate the voice agent
-      const widget = document.querySelector('elevenlabs-convai') as any;
-      console.log('Found widget:', widget);
-
-      if (widget) {
-        // Try different methods to activate the widget
-        let activated = false;
-
-        // Method 1: Try the click method
-        if (widget.click && typeof widget.click === 'function') {
-          try {
-            widget.click();
-            activated = true;
-            console.log('Widget activated via click method');
-          } catch (e) {
-            console.log('Click method failed:', e);
-          }
-        }
-
-        // Method 2: Try the open method
-        if (!activated && widget.open && typeof widget.open === 'function') {
-          try {
-            widget.open();
-            activated = true;
-            console.log('Widget activated via open method');
-          } catch (e) {
-            console.log('Open method failed:', e);
-          }
-        }
-
-        // Method 3: Try triggering a mouse event
-        if (!activated) {
-          try {
-            const event = new MouseEvent('click', {
-              view: window,
-              bubbles: true,
-              cancelable: true
-            });
-            widget.dispatchEvent(event);
-            activated = true;
-            console.log('Widget activated via mouse event');
-          } catch (e) {
-            console.log('Mouse event method failed:', e);
-          }
-        }
-
-        if (activated) {
-          setVoiceAgentActive(true);
-        } else {
-          console.log('All activation methods failed, navigating to AI assistant page');
-          navigate("/ai-assistant");
-        }
-      } else {
-        console.log('Widget not found, navigating to AI assistant page');
+      const activated = activateVoiceAgent();
+      
+      if (!activated) {
+        console.log('Voice agent activation failed, navigating to AI assistant page');
         navigate("/ai-assistant");
       }
     } else {

--- a/src/components/ui/figma-navbar.tsx
+++ b/src/components/ui/figma-navbar.tsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect, useRef } from "react"
 import { ChevronDown } from "lucide-react"
 import { cn } from "@/lib/utils"
-import { AIAssistantButton } from "./ai-assistant-button"
 
 interface NavItem {
   name: string
@@ -236,9 +235,8 @@ export function FigmaNavBar({ className }: NavBarProps) {
           ))}
         </nav>
 
-        {/* AI Assistant & Contact Us Buttons */}
-        <div className="hidden md:flex items-center space-x-3">
-          <AIAssistantButton isMobile={false} />
+        {/* Contact Us Button */}
+        <div className="hidden md:flex items-center">
           <a
             href="https://c81dcd8934204bc39d562f1debf9ab43-8e591c7522cc4e05a161006e3.fly.dev/services"
             className="px-6 py-2 bg-white text-[black] rounded-full text-sm lg:text-base font-medium hover:bg-gray-50 transition-colors duration-200 cursor-pointer"
@@ -287,10 +285,7 @@ export function FigmaNavBar({ className }: NavBarProps) {
                 )}
               </a>
             ))}
-            <div className="border-t border-white/10 mt-3 pt-3 space-y-3">
-              <div className="flex justify-center">
-                <AIAssistantButton isMobile={true} />
-              </div>
+            <div className="border-t border-white/10 mt-3 pt-3">
               <a
                 href="/contact"
                 className="block text-white/80 hover:text-white transition-colors duration-200 py-2 text-center"

--- a/src/hooks/use-voice-agent.tsx
+++ b/src/hooks/use-voice-agent.tsx
@@ -1,0 +1,157 @@
+import { useEffect, useState } from "react";
+
+export function useVoiceAgent() {
+  const [voiceAgentLoaded, setVoiceAgentLoaded] = useState(false);
+
+  useEffect(() => {
+    // Add the ElevenLabs ConvAI script exactly as provided
+    const script = document.createElement('script');
+    script.src = 'https://unpkg.com/@elevenlabs/convai-widget-embed';
+    script.async = true;
+    script.type = 'text/javascript';
+    script.id = 'elevenlabs-convai-script';
+
+    // Only add if not already present
+    if (!document.getElementById('elevenlabs-convai-script')) {
+      document.head.appendChild(script);
+
+      // Wait for script to load before creating widget
+      script.onload = () => {
+        // Add the ConvAI widget element exactly as provided
+        let convaiWidget = document.getElementById('elevenlabs-convai-widget');
+        if (!convaiWidget) {
+          convaiWidget = document.createElement('elevenlabs-convai');
+          convaiWidget.id = 'elevenlabs-convai-widget';
+          convaiWidget.setAttribute('agent-id', 'agent_9601k3c0dph4eezaj7qxsf837x4z');
+
+          // Apply styles to match the diff requirements
+          Object.assign(convaiWidget.style, {
+            bottom: '0px',
+            color: 'rgb(0, 0, 0)',
+            display: 'block',
+            fontFamily: 'Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif',
+            fontWeight: '400',
+            left: '0px',
+            pointerEvents: 'auto',
+            position: 'fixed',
+            right: '0px',
+            scrollbarColor: 'rgb(229, 231, 235) rgba(0, 0, 0, 0)',
+            top: '192px',
+            zIndex: '1000'
+          });
+
+          document.body.appendChild(convaiWidget);
+
+          console.log('ElevenLabs voice agent widget created');
+          setVoiceAgentLoaded(true);
+        }
+      };
+    } else {
+      // Script already exists, check if widget exists
+      let convaiWidget = document.getElementById('elevenlabs-convai-widget');
+      if (!convaiWidget) {
+        convaiWidget = document.createElement('elevenlabs-convai');
+        convaiWidget.id = 'elevenlabs-convai-widget';
+        convaiWidget.setAttribute('agent-id', 'agent_9601k3c0dph4eezaj7qxsf837x4z');
+
+        // Apply styles to match the diff requirements
+        Object.assign(convaiWidget.style, {
+          bottom: '0px',
+          color: 'rgb(0, 0, 0)',
+          display: 'block',
+          fontFamily: 'Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif',
+          fontWeight: '400',
+          left: '0px',
+          pointerEvents: 'auto',
+          position: 'fixed',
+          right: '0px',
+          scrollbarColor: 'rgb(229, 231, 235) rgba(0, 0, 0, 0)',
+          top: '192px',
+          zIndex: '1000'
+        });
+
+        document.body.appendChild(convaiWidget);
+        console.log('ElevenLabs voice agent widget created (script existed)');
+      }
+      setVoiceAgentLoaded(true);
+    }
+
+    // Additional check for widget availability
+    const checkWidget = setTimeout(() => {
+      const widget = document.querySelector('elevenlabs-convai');
+      if (widget) {
+        console.log('ElevenLabs voice agent widget found:', widget);
+        setVoiceAgentLoaded(true);
+      } else {
+        console.log('ElevenLabs voice agent widget not found');
+      }
+    }, 3000);
+
+    return () => {
+      clearTimeout(checkWidget);
+      // Note: We don't cleanup the script and widget here anymore
+      // since we want them to persist even if components using this hook unmount
+    };
+  }, []);
+
+  const activateVoiceAgent = () => {
+    console.log('Attempting to activate voice agent, loaded:', voiceAgentLoaded);
+
+    if (voiceAgentLoaded) {
+      const widget = document.querySelector('elevenlabs-convai') as any;
+      console.log('Found widget:', widget);
+
+      if (widget) {
+        // Try different methods to activate the widget
+        let activated = false;
+
+        // Method 1: Try the click method
+        if (widget.click && typeof widget.click === 'function') {
+          try {
+            widget.click();
+            activated = true;
+            console.log('Widget activated via click method');
+          } catch (e) {
+            console.log('Click method failed:', e);
+          }
+        }
+
+        // Method 2: Try the open method
+        if (!activated && widget.open && typeof widget.open === 'function') {
+          try {
+            widget.open();
+            activated = true;
+            console.log('Widget activated via open method');
+          } catch (e) {
+            console.log('Open method failed:', e);
+          }
+        }
+
+        // Method 3: Try triggering a mouse event
+        if (!activated) {
+          try {
+            const event = new MouseEvent('click', {
+              view: window,
+              bubbles: true,
+              cancelable: true
+            });
+            widget.dispatchEvent(event);
+            activated = true;
+            console.log('Widget activated via mouse event');
+          } catch (e) {
+            console.log('Mouse event method failed:', e);
+          }
+        }
+
+        return activated;
+      }
+    }
+    
+    return false;
+  };
+
+  return {
+    voiceAgentLoaded,
+    activateVoiceAgent
+  };
+}


### PR DESCRIPTION
## Purpose

The user wanted to remove the AI assistant button from the navigation while preserving the AI voice agent functionality. They also requested to organize the navigation with proper page names in sequence and remove unnecessary elements.

## Code changes

- **Created global voice agent hook**: Extracted voice agent logic into `useVoiceAgent` hook for reusable functionality
- **Added global VoiceAgent component**: Created wrapper component that loads voice agent globally in App.tsx
- **Removed AI assistant buttons**: Completely removed AIAssistantButton from both desktop and mobile navigation in FigmaNavBar
- **Simplified navigation layout**: Cleaned up navigation structure by removing AI button containers and spacing
- **Refactored button component**: Updated AIAssistantButton to use the new hook instead of inline voice agent logic

The voice agent now loads globally and persists across the application without being tied to the navigation button, while the navigation is simplified to focus on core pages and contact functionality.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 76`

🔗 [Edit in Builder.io](https://builder.io/app/projects/6085b987de594c428e7928993f4e2caf/pixel-haven)

👀 [Preview Link](https://6085b987de594c428e7928993f4e2caf-pixel-haven.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>6085b987de594c428e7928993f4e2caf</projectId>-->
<!--<branchName>pixel-haven</branchName>-->