### PR TITLE
Fix hero section height and image styling

### DIFF
--- a/src/pages/ResidentialProperties.tsx
+++ b/src/pages/ResidentialProperties.tsx
@@ -221,7 +221,8 @@ const ResidentialProperties = () => {
         <motion.img
           src="https://api.builder.io/api/v1/image/assets/TEMP/8d4ffccf04b7eb57f4736f6c8132230ec51f5a91?width=3810"
           alt="Residential Properties Background"
-          className="absolute inset-0 w-full h-full object-cover"
+          className="absolute inset-0 object-cover"
+          style={{ height: '65%', width: '126%' }}
           initial={{ opacity: 0, scale: 1.05 }}
           animate={{ opacity: 1, scale: 1 }}
           transition={{
@@ -244,7 +245,7 @@ const ResidentialProperties = () => {
 
       {/* Properties Section */}
       <motion.section
-        className="py-12 md:py-20 px-4 md:px-8 lg:px-16 xl:px-24"
+        className="pb-12 md:pb-20 px-4 md:px-8 lg:px-16 xl:px-24"
         initial="hidden"
         whileInView="visible"
         viewport={{ once: true, margin: "-50px" }}

--- a/src/pages/ResidentialProperties.tsx
+++ b/src/pages/ResidentialProperties.tsx
@@ -212,7 +212,7 @@ const ResidentialProperties = () => {
 
       {/* Hero Section */}
       <motion.section
-        className="relative h-[600px] md:h-[901px] flex items-center justify-center overflow-hidden"
+        className="relative h-[600px] md:h-[732px] flex items-center justify-center overflow-hidden"
         initial="hidden"
         animate="visible"
         variants={containerVariants}
@@ -222,7 +222,7 @@ const ResidentialProperties = () => {
           src="https://api.builder.io/api/v1/image/assets/TEMP/8d4ffccf04b7eb57f4736f6c8132230ec51f5a91?width=3810"
           alt="Residential Properties Background"
           className="absolute inset-0 object-cover"
-          style={{ height: '65%', width: '126%' }}
+          style={{ height: '81%', width: '126%' }}
           initial={{ opacity: 0, scale: 1.05 }}
           animate={{ opacity: 1, scale: 1 }}
           transition={{
@@ -233,7 +233,7 @@ const ResidentialProperties = () => {
         />
 
         {/* Hero Content */}
-        <div className="relative z-10 text-center px-4 pb-[200px]">
+        <div className="relative z-10 text-center px-4 pb-[105px]">
           <motion.h1
             className="font-instrument text-[100px] font-normal leading-[236px] text-white tracking-[1px] h-[359px]"
             variants={headlineVariants}


### PR DESCRIPTION
## Purpose
The user requested adjustments to the ResidentialProperties page hero section to improve the visual layout. Specifically, they wanted to remove extra whitespace and set the hero section height to 732px for better proportions.

## Code changes
- Updated hero section height from 901px to 732px on medium+ screens
- Modified hero background image styling to use inline styles with specific height (81%) and width (126%) instead of full coverage
- Reduced hero content bottom padding from 200px to 105px
- Changed properties section top padding to bottom-only padding to eliminate extra spacing

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 80`

🔗 [Edit in Builder.io](https://builder.io/app/projects/54e4ff0cf97b49899924b4631270fa48/pulse-world)

👀 [Preview Link](https://54e4ff0cf97b49899924b4631270fa48-pulse-world.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>54e4ff0cf97b49899924b4631270fa48</projectId>-->
<!--<branchName>pulse-world</branchName>-->