### PR TITLE
Remove About Us button from navbar

### DIFF
--- a/src/components/ui/figma-navbar.tsx
+++ b/src/components/ui/figma-navbar.tsx
@@ -16,7 +16,6 @@ interface NavBarProps {
 
 const navItems: NavItem[] = [
   { name: 'Home', url: '/' },
-  { name: 'About us', url: '/about' },
   { name: 'Residential', url: '/residential' },
   { name: 'Commercial', url: '/commercial' },
   { name: 'Industrial', url: '/industrial' },


### PR DESCRIPTION
### Summary
Removes the "About us" link from the site's navigation bar.

### Problem
The "About us" button was requested to be removed from the top navigation menu.

### Solution
Updated the static `navItems` configuration in the navbar component to exclude the "About us" entry.

### Key Changes
- Removed the "About us" item from the `navItems` array in `src/components/ui/figma-navbar.tsx`.

---

<a href="https://builder.io/app/projects/b6b75576627c49bfb4f10326d352bb5f/multi-verse-c8yv5wyd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://b6b75576627c49bfb4f10326d352bb5f-multi-verse-c8yv5wyd.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 114`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>b6b75576627c49bfb4f10326d352bb5f</projectId>-->
<!--<branchName>multi-verse-c8yv5wyd</branchName>-->